### PR TITLE
Unicode 3.6 and 2.7 tweak.

### DIFF
--- a/pyembroidery/PyEmbroidery.py
+++ b/pyembroidery/PyEmbroidery.py
@@ -584,7 +584,11 @@ def write_embroidery(writer, pattern, stream, settings=None):
                 pass
         pattern = pattern.get_normalized_pattern(settings)
 
-    if isinstance(stream, str):
+    try:
+        basestring
+    except NameError:
+        basestring = str
+    if isinstance(stream, basestring):
         with open(stream, "wb") as stream:
             writer.write(pattern, stream, settings)
     else:


### PR DESCRIPTION
Should check against basestring unless it's 3.6 and there's no such thing. Should then NameError and set basestring = str and proceed as normal regardless if using 3.6 or 2.7.