### PR TITLE
Corrections for trims for the VP3Reader/Writer

### DIFF
--- a/pyembroidery/Vp3Reader.py
+++ b/pyembroidery/Vp3Reader.py
@@ -55,6 +55,8 @@ def read(f, out, settings=None):
     count_colors = read_int_16be(f)
     for i in range(0, count_colors):
         vp3_read_colorblock(f, out, center_x, center_y)
+        if (i + 1) < count_colors:  # Don't add the color change on the final read.
+            out.color_change()
 
 
 def vp3_read_colorblock(f, out, center_x, center_y):
@@ -96,10 +98,7 @@ def vp3_read_colorblock(f, out, center_x, center_y):
         elif y == 0x02:
             pass  # ends long stitch mode.
         elif y == 0x03:
-            out.end(0, 0)
-            return
-    out.trim()
-    out.color_change()
+            out.trim()
 
 
 def vp3_read_thread(f):

--- a/pyembroidery/Vp3Writer.py
+++ b/pyembroidery/Vp3Writer.py
@@ -225,11 +225,12 @@ def write_stitches_block(f, stitches, first_pos_x, first_pos_y):
         y = stitch[1]
         flags = stitch[2] & COMMAND_MASK
         if flags == END:
-            f.write(b'\x80\x03')
+            f.write(b'\x80\x03')  # Write a trim at end of file.
             break
         elif flags == COLOR_CHANGE:
             continue
         elif flags == TRIM:
+            f.write(b'\x80\x03')
             continue
         elif flags == SEQUIN_MODE:
             continue

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pyembroidery",
-    version="1.4.2",
+    version="1.4.3",
     author="Tatarize",
     author_email="tatarize@gmail.com",
     description="Embroidery IO library",


### PR DESCRIPTION
Corrects interpolation of 0x80 0x03 from END to TRIM. This should correct native trimming issues for machines utilizing VP3 files.