### PR TITLE
PMV Y-axis flipped.

### DIFF
--- a/pyembroidery/PmvReader.py
+++ b/pyembroidery/PmvReader.py
@@ -40,7 +40,7 @@ def read_pmv_stitches(f, out, settings=None):
             if x > 32:
                 x = -(64 - x)  # This is a 6 bit signed number.
             x *= 2.5
-            y *= 2.5
+            y *= -2.5
             dx = x
             out.stitch_abs(px + x, y)  # This is a hybrid relative, absolute value.
             px += dx

--- a/pyembroidery/PmvWriter.py
+++ b/pyembroidery/PmvWriter.py
@@ -14,7 +14,7 @@ def write(pattern, f, settings=None):
     for stitch in pattern.stitches:
         data = stitch[2]
         x = stitch[0]
-        y = stitch[1]
+        y = -stitch[1]
         if data == STITCH or data == JUMP:
             point_count += 1
             if x > max_x:
@@ -57,7 +57,7 @@ def write(pattern, f, settings=None):
             break
         data = stitch[2] & COMMAND_MASK
         x = stitch[0]
-        y = stitch[1]
+        y = -stitch[1]
         x *= scale_x
         y -= center_y
         y *= scale_y

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pyembroidery",
-    version="1.4.21",
+    version="1.4.22",
     author="Tatarize",
     author_email="tatarize@gmail.com",
     description="Embroidery IO library",


### PR DESCRIPTION
The loading and writing routines need to be y-flipped to work correctly. See EmbroidePy/MaKe-stitch#2