### PR TITLE
Add missing 'extensions' key for ZHS

### DIFF
--- a/pyembroidery/EmbPattern.py
+++ b/pyembroidery/EmbPattern.py
@@ -1330,6 +1330,7 @@ class EmbPattern:
         yield ({
             "description": "Zeng Hsing Embroidery Format",
             "extension": "zhs",
+            "extensions": ("zhs",),
             "mimetype": "application/x-zhs",
             "category": "embroidery",
             "reader": ZhsReader


### PR DESCRIPTION
Add missing 'extensions' key for ZHS in supported_formats dictionary