### PR TITLE
Import GenericWriter Correctly

### DIFF
--- a/pyembroidery/GenericWriter.py
+++ b/pyembroidery/GenericWriter.py
@@ -412,20 +412,13 @@ class GenericWriter:
             self.block_closing = True
 
     def write(self):
-        pattern = self.pattern
-        f = self.f
-        settings = self.settings
-
-        if settings is None:
-            return
-
         # DOCUMENT STATISTICS
         self.set_document_statistics()
 
         self.open_pattern()
         if self.metadata_entry is not None:
-            for i, key in enumerate(pattern.extras):
-                value = pattern.extras[key]
+            for i, key in enumerate(self.pattern.extras):
+                value = self.pattern.extras[key]
                 self.format_dictionary.update({
                     "metadata_index": i,
                     "metadata_key": str(key),
@@ -436,7 +429,7 @@ class GenericWriter:
                 )
 
         if self.thread_entry is not None:
-            for i, thread in enumerate(pattern.threadlist):
+            for i, thread in enumerate(self.pattern.threadlist):
                 self.format_dictionary.update({
                     "thread_index": i,
                     "thread_color": thread.hex_color(),
@@ -453,7 +446,7 @@ class GenericWriter:
                 write_string_utf8(
                     self.f, self.thread_entry.format_map(self.format_dictionary)
                 )
-        for self.command_index in range(0, len(pattern.stitches)):
+        for self.command_index in range(0, len(self.pattern.stitches)):
             self.update_command()
             write_segment = self.get_write_segment(self.cmd)
 
@@ -462,7 +455,7 @@ class GenericWriter:
                 if isinstance(write_segment, dict):
                     key, default = write_segment[None]
                     key = key.format_map(self.format_dictionary)
-                    write_segment = write_segment.get(key,default)
+                    write_segment = write_segment.get(key, default)
                 self.update_positions(self.x, self.y, self.cmd)
                 if self.cmd == SEQUIN_MODE:
                     self.open_document()

--- a/pyembroidery/__init__.py
+++ b/pyembroidery/__init__.py
@@ -7,6 +7,7 @@ from .EmbMatrix import EmbMatrix
 from .EmbPattern import EmbPattern
 from .EmbThread import EmbThread
 from .EmbCompress import compress, expand
+import pyembroidery.GenericWriter as GenericWriter
 
 # items available in a sub-heirarchy (e.g. pyembroidery.PecGraphics.get_graphic_as_string)
 from .PecGraphics import get_graphic_as_string

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pyembroidery",
-    version="1.4.35",
+    version="1.4.36",
     author="Tatarize",
     author_email="tatarize@gmail.com",
     description="Embroidery IO library",


### PR DESCRIPTION
Correct the generic writer input to permit external scripting

```python
from pyembroidery import *
import sys

gcode_writer_dict = {
    "scale": (0.1, -0.1),
    "thread_change_command": NEEDLE_SET,
    "write_speeds": True,
    "pattern_start": "G21 G90 F6000 (mm units, absolute positioning, speed)\n",
    "thread_entry": "(Thread{thread_index}: {thread_color} {thread_description} {thread_brand} {thread_catalog_number})\n",
    "color_start": "G00 X{x:.3f} Y{y:.3f} (Starting new location)\n",
    "stitch": "G01 X{x:.3f} Y{y:.3f}\n",
    "slow": "F1000\n",
    "fast": "F6000\n",
    "needle_set": {None: ("{cmd_needle}", "default value {cmd_needle}\n"), "1": "G0A51\n", "2": "G0B8\n"},
    "end": "M30\n",
}

EmbPattern.write_embroidery(
    GenericWriter,
    EmbPattern(sys.argv[1]),
    f"{sys.argv[1]}.gcode",
    gcode_writer_dict,
)
```