### PR TITLE
TBF Write Flipped

### DIFF
--- a/pyembroidery/TbfWriter.py
+++ b/pyembroidery/TbfWriter.py
@@ -101,22 +101,22 @@ def write(pattern, f, settings=None):
 
         if data == STITCH:
             cmd = 0x80
-            f.write(bytes(bytearray([dx & 0xFF, dy & 0xFF, cmd])))
+            f.write(bytes(bytearray([dx & 0xFF, -dy & 0xFF, cmd])))
         elif data == JUMP:
             cmd = 0x90
-            f.write(bytes(bytearray([dx & 0xFF, dy & 0xFF, cmd])))
+            f.write(bytes(bytearray([dx & 0xFF, -dy & 0xFF, cmd])))
         elif data == STOP:
             cmd = 0x40
-            f.write(bytes(bytearray([dx & 0xFF, dy & 0xFF, cmd])))
+            f.write(bytes(bytearray([dx & 0xFF, -dy & 0xFF, cmd])))
         elif data == TRIM:
             cmd = 0x86
-            f.write(bytes(bytearray([dx & 0xFF, dy & 0xFF, cmd])))
+            f.write(bytes(bytearray([dx & 0xFF, -dy & 0xFF, cmd])))
         elif data == NEEDLE_SET:
             cmd = 0x81
-            f.write(bytes(bytearray([dx & 0xFF, dy & 0xFF, cmd])))
+            f.write(bytes(bytearray([dx & 0xFF, -dy & 0xFF, cmd])))
         elif data == END:
             cmd = 0x8F
-            f.write(bytes(bytearray([dx & 0xFF, dy & 0xFF, cmd])))
+            f.write(bytes(bytearray([dx & 0xFF, -dy & 0xFF, cmd])))
             break
     # Terminal character.
     f.write(b"\x1a")

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         'Topic :: Software Development :: Libraries :: Python Modules'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pyembroidery",
-    version="1.5.0",
+    version="1.5.1",
     author="Tatarize",
     author_email="tatarize@gmail.com",
     description="Embroidery IO library",

--- a/test/test_convert_tbf.py
+++ b/test/test_convert_tbf.py
@@ -212,6 +212,23 @@ class TestConverts(unittest.TestCase):
         self.addCleanup(os.remove, file1)
         self.addCleanup(os.remove, file2)
 
+    def test_tbf_flipped(self):
+        """
+        Test whether tbf is flipped on subsequent loads. This creates a pattern. Saves/loads, then save/loads.
+        These patterns should be the same but a bug in 1.5.0 was flipping TBF patterns on write.
+        """
+        pattern = get_fractal_pattern()
+        file1 = "fractal1.tbf"
+        file2 = "fractal2.tbf"
+        pattern.write(file1)
+        f1 = read_tbf(file1)
+        f1.write(file2)
+        f2 = read_tbf(file2)
+        for i in range(len(f1.stitches)):
+            self.assertEqual(f1.stitches[i], f2.stitches[i])
+        self.addCleanup(os.remove, file1)
+        self.addCleanup(os.remove, file2)
+
     def test_needle_tbf_range(self):
         file1 = "test_range8.tbf"
         file2 = "test_range8.ct0"


### PR DESCRIPTION
The write out of TBF is wrongly non-flipped from default coord system and it should be flipped.

